### PR TITLE
IOException cause propagation for HTTP/networking errors.

### DIFF
--- a/src/main/java/com/wrapper/spotify/SpotifyHttpManager.java
+++ b/src/main/java/com/wrapper/spotify/SpotifyHttpManager.java
@@ -159,9 +159,6 @@ public class SpotifyHttpManager implements HttpManager {
 
       handleErrorResponseBody(responseBody);
       return responseBody;
-
-    } catch (IOException e) {
-      throw new IOException();
     } finally {
       method.releaseConnection();
     }


### PR DESCRIPTION
Networking errors (e.g. `UnknownHostException`) are currently processed without the root cause of the problem.

This fix should enable a straightforward stack trace message, while keeping the contract of the base class intact.